### PR TITLE
Make it possible to pass objects to `breadcrumbs`.

### DIFF
--- a/lib/croutons/controller.rb
+++ b/lib/croutons/controller.rb
@@ -12,10 +12,11 @@ module Croutons
 
     private
 
-    def breadcrumbs
+    def breadcrumbs(objects = {})
       template = lookup_context.find_template(@_template, @_prefixes)
       template_identifier = template.virtual_path.gsub('/', '_')
-      breadcrumbs = breadcrumb_trail.breadcrumbs(template_identifier, view_assigns)
+      objects.reverse_merge!(view_assigns)
+      breadcrumbs = breadcrumb_trail.breadcrumbs(template_identifier, objects)
       render_to_string(
         partial: 'breadcrumbs/breadcrumbs',
         locals: { breadcrumbs: breadcrumbs },

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -32,9 +32,9 @@ class RailsApp
     end
   end
 
-  def add_breadcrumbs_to_layout
-    transform_file(path("app/views/layouts/application.html.erb")) do |content|
-      content.sub("<body>", "<body>\n<%= breadcrumbs %>")
+  def add_to_view(name, content_to_add)
+    transform_file(path("app/views/#{name}.html.erb")) do |content|
+      content << content_to_add
     end
   end
 


### PR DESCRIPTION
By making it possible to pass object to the `breadcrumbs` helper we allow
user to make objects available to the `BreadcrumbTrail` without adding more
view_assigns.
