### PR TITLE
Adjust the method definitions of `method_missing` and `respond_to_missing?`

### DIFF
--- a/lib/croutons/breadcrumb_trail.rb
+++ b/lib/croutons/breadcrumb_trail.rb
@@ -15,7 +15,7 @@ module Croutons
       build_breadcrumbs
     end
 
-    def method_missing(name, *args)
+    def method_missing(name, *args, &block)
       if respond_to_missing?(name)
         Rails.application.routes.url_helpers.public_send(name, *args)
       else
@@ -23,8 +23,8 @@ module Croutons
       end
     end
 
-    def respond_to_missing?(name)
-      Rails.application.routes.url_helpers.respond_to?(name)
+    def respond_to_missing?(name, include_private = false)
+      Rails.application.routes.url_helpers.respond_to?(name) || super
     end
 
     private

--- a/lib/croutons/breadcrumb_trail.rb
+++ b/lib/croutons/breadcrumb_trail.rb
@@ -15,7 +15,7 @@ module Croutons
       build_breadcrumbs
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args)
       if respond_to_missing?(name)
         Rails.application.routes.url_helpers.public_send(name, *args)
       else


### PR DESCRIPTION
Let `respond_to_missing?` take a second optional parameter (as it should be.) Here is the documentation for the `respond_to_missing?` method on `Object`.

Note: I linked to the documentation for Ruby 2.1.3 because that's the version specified in the `.ruby-version` file at the root of the project.

http://ruby-doc.org/core-2.1.3/Object.html#method-i-respond_to_missing-3F

I also amended the definition of the `method_missing` method to include the block parameter.

**Edit:** The reason for this pull request is that the missing argument in the definition of the `respond_to_missing?` method is problematic calling `respond_to?` from a (user-defined) subclass of `Croutons::BreadcrumbTrail` which ends up calling `respond_to_missing?` and fails with the following error:

```
ArgumentError - wrong number of arguments (given 2, expected 1):
  croutons (0.0.2) lib/croutons/breadcrumb_trail.rb:26:in `respond_to_missing?'
```
