### PR TITLE
Support Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     croutons (0.0.2)
       rails (>= 4.2.0)
+      ruby2_keywords
 
 GEM
   remote: https://rubygems.org/
@@ -63,16 +64,21 @@ GEM
     concurrent-ruby (1.1.4)
     crass (1.0.5)
     diff-lcs (1.3)
+    digest (3.1.1)
     erubi (1.8.0)
-    globalid (0.4.1)
-      activesupport (>= 4.2.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
     i18n (1.4.0)
       concurrent-ruby (~> 1.0)
+    io-wait (0.3.0)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
@@ -82,7 +88,20 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nio4r (2.3.1)
+    net-imap (0.2.2)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.0)
+      digest
+      net-protocol
+      timeout
+    nio4r (2.5.8)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     public_suffix (3.0.3)
@@ -132,21 +151,24 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    sprockets (3.7.2)
+    ruby2_keywords (0.0.5)
+    sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    strscan (3.0.5)
     thor (0.20.3)
     thread_safe (0.3.6)
+    timeout (0.3.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)

--- a/croutons.gemspec
+++ b/croutons.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
   s.add_dependency "rails", ">= 4.2.0"
+  s.add_dependency "ruby2_keywords"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "capybara"
   s.add_development_dependency "sqlite3"

--- a/lib/croutons/breadcrumb_trail.rb
+++ b/lib/croutons/breadcrumb_trail.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'croutons/breadcrumb'
 
 module Croutons
@@ -44,7 +45,7 @@ module Croutons
       breadcrumbs << Breadcrumb.new(*args)
     end
 
-    def t(*args)
+    ruby2_keywords def t(*args)
       I18n.t(*args)
     end
   end


### PR DESCRIPTION
Ruby 3 changes how keyword arguments work by separating them from positional arguments. Running on Ruby 3 requires explicitly delegating keyword arguments. By using the ruby2_keywords gem we can maintain backwards compatibility with Ruby versions prior to 2.7.

More info: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This PR also upgrades mimemagic since the previously used version was yanked due to licensing concerns.