### PR TITLE
Add deprecation note to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Deprecated as of September 20, 2024
+
+This project is no longer maintained. If you wish to continue to develop this code yourself, we recommend you fork it.
+
 Croutons
 ========
 


### PR DESCRIPTION
Croutons is being deprecated because we no longer used it in our client projects and there are other more up to date libraries available.